### PR TITLE
fix: HJManagedImageV blocks default touch event chain

### DIFF
--- a/HJCacheClasses/HJManagedImageV.m
+++ b/HJCacheClasses/HJManagedImageV.m
@@ -172,9 +172,9 @@
 	if (onImageTap) {
 		[onImageTap invoke];
 	}
+    else {
+        [super touchesEnded:touches withEvent:event];
+    }
 }
-
-
-
 
 @end


### PR DESCRIPTION
call default touch end event when onImageTap callback does not set, otherwise this view blocks default touch event chain.

e.g. HJManagedImageV on UITableViewCell blocks didSelectRowAtIndexPath delegation. This patch fixed that issue.
