### PR TITLE
Make it possible to see loaded images while still scrolling

### DIFF
--- a/DemoClasses/Flickr/FlickrSearchTVC.m
+++ b/DemoClasses/Flickr/FlickrSearchTVC.m
@@ -24,6 +24,7 @@
 	
 	// Create the object manager
 	objMan = [[HJObjManager alloc] initWithLoadingBufferSize:6 memCacheSize:20];
+  objMan.connectionRunLoopMode = NSRunLoopCommonModes;
 	
 	//if you are using for full screen images, you'll need a smaller memory cache than the defaults,
 	//otherwise the cached images will get you out of memory quickly

--- a/HJCacheClasses/HJMOHandler.h
+++ b/HJCacheClasses/HJMOHandler.h
@@ -33,6 +33,7 @@
 	HJWeakMutableArray* users;
 	HJObjManager* objManager;
 	HJMOPolicy* ownPolicy;
+  NSString* connectionRunLoopMode;
 }
 
 @property (readonly) enum HJMOState state;
@@ -45,6 +46,7 @@
 @property (nonatomic, retain) id managedObj;
 @property (nonatomic, assign) HJObjManager* objManager;
 @property (nonatomic, retain) HJMOPolicy* ownPolicy;
+@property (nonatomic, retain) NSString* connectionRunLoopMode;
 
 
 -(HJMOHandler*)initWithOid:(id)oid_ url:(NSURL*)url_  objManager:objManager_;

--- a/HJCacheClasses/HJMOHandler.m
+++ b/HJCacheClasses/HJMOHandler.m
@@ -25,6 +25,7 @@
 @synthesize managedObj;
 @synthesize objManager;
 @synthesize ownPolicy;
+@synthesize connectionRunLoopMode;
 
 
 -(HJMOHandler*)initWithOid:(id)oid_ url:(NSURL*)url_  objManager:objManager_{
@@ -260,7 +261,19 @@
 	NSURLRequest* request = [NSURLRequest requestWithURL:url 
 										  cachePolicy:NSURLRequestReloadIgnoringLocalCacheData 
 								          timeoutInterval:policy.urlTimeoutTime];
-	self.urlConn = [[NSURLConnection alloc] initWithRequest:request delegate:self];
+  
+  if(self.connectionRunLoopMode){
+    self.urlConn = [[NSURLConnection alloc]
+                    initWithRequest:request
+                    delegate:self
+                    startImmediately:NO];
+    [self.urlConn scheduleInRunLoop:[NSRunLoop currentRunLoop]
+                            forMode:self.connectionRunLoopMode];
+    [self.urlConn start];
+  }else{
+    self.urlConn = [[NSURLConnection alloc] initWithRequest:request delegate:self];
+  }
+  
 	[urlConn release];
 	if (urlConn==nil) {
 		NSLog(@"HJMOHandler nil URLConnection for %@",url);

--- a/HJCacheClasses/HJObjManager.h
+++ b/HJCacheClasses/HJObjManager.h
@@ -30,6 +30,8 @@
 	HJCircularBuffer* memCache;
 	HJMOHandler* flyweightManagedState;
 	HJMOFileCache* fileCache;
+  NSString* connectionRunLoopMode;
+  
 }
 
 /*
@@ -53,6 +55,12 @@
  Internal state. This is the memory cache of managed objects
  */
 @property (nonatomic, retain) HJCircularBuffer* memCache;
+
+/*
+ The run loop mode to use for NSConnections. Only set for subsequent managed object.
+ Leave nil to use the default.
+ */
+@property (nonatomic, retain) NSString* connectionRunLoopMode;
 
 
 /*

--- a/HJCacheClasses/HJObjManager.m
+++ b/HJCacheClasses/HJObjManager.m
@@ -15,6 +15,7 @@
 @synthesize policy;
 @synthesize loadingHandlers;
 @synthesize memCache, fileCache;
+@synthesize connectionRunLoopMode;
 
 
 
@@ -94,6 +95,8 @@
 		if (handler==nil) {
 			//was not in loadingHandlers or memCache. have to make a new handler to load image
 			handler = [[HJMOHandler alloc] initWithOid:user.oid url:user.url objManager:self];
+      handler.connectionRunLoopMode = self.connectionRunLoopMode;
+      
 			handlerWasAllocedInThisCall=YES;
 		} else {
 			//NSLog(@"HJCache loading from memCache");


### PR DESCRIPTION
I've added a property to `HJObjManager` and `HJMOHandler` called `connectionRunLoopMode`. When set it gets passed to `scheduleInRunLoop:forMode:` of the `NSURLConnection`s that get created. This allows you to set the connection run loop mode to `NSRunLoopCommonModes` when fetching images for `HJManagedImageV` so that requests return and images get displayed while the main run loop is in a UI event tracking mode, e.g. when a table is being scrolled. 

I've also updated the `FlickrSearchTVC` in the demo app to show the newly possible behavior. 

Alternately it might be worth abstracting away the specific run loop mode setting because as far as I can tell there aren't many use cases for setting it to something other than `NSRunLoopCommonModes`. On the other hand, setting it to that explicitly makes it more likely people will be aware of what they're actually doing. 
