### PR TITLE
Change contentMode in setImage of HJManagedImageV

### DIFF
--- a/HJCacheClasses/HJManagedImageV.m
+++ b/HJCacheClasses/HJManagedImageV.m
@@ -132,7 +132,7 @@
 	
 	[imageView removeFromSuperview];
 	self.imageView = [[[UIImageView alloc] initWithImage:theImage] autorelease];
-	imageView.contentMode = UIViewContentModeScaleAspectFit;
+	imageView.contentMode = self.contentMode;
 	imageView.autoresizingMask = ( UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight );
 	[self addSubview:imageView];
 	imageView.frame = self.bounds;


### PR DESCRIPTION
Change the internal imageView's contentMode to reflect whatever the HJManagedImageV's contentMode is so we can use this easier in Interface Builder and in our custom classes.

This allows you to set managedImageV.contentMode and it passes through to the managedImageV.imageView.contentMode.
